### PR TITLE
Add link to santiagosommer github

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@
     </section>
 
     <div class="icons">
-        <a href="#" ><i class="ri-github-fill"></i></a>
+        <a href="https://github.com/santiagosommer" ><i class="ri-github-fill"></i></a>
     </div>
 
     <div class="scroll-down">


### PR DESCRIPTION
This pull request includes a small change to the `index.html` file. The change updates the GitHub link to point to Santiago Sommer's GitHub profile.

* [`index.html`](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L53-R53): Updated the GitHub link to point to `https://github.com/santiagosommer` instead of `#`.